### PR TITLE
🐛 FIX: Change link for Service Status

### DIFF
--- a/public/includes/top.php
+++ b/public/includes/top.php
@@ -15,7 +15,8 @@ $navbar_links = array(
     array("The Team", "/team"),
     array("Our Projects", "/projects"),
     array("Contact Us", "/contact"),
-    array("Service Status", "/status"),
+    // array("Service Status", "/status"),
+    array("Service Status", "https://status.citygate.io"),
 );
 ?>
 


### PR DESCRIPTION
Change the link for the navbar option 'Service Status' to `https://status.citygate.io`.

Signed-off-by: Luke Tainton <luke@tainton.uk>